### PR TITLE
Update recommended MathJax config to match actual secure (#139) config

### DIFF
--- a/public/res/WELCOME.md
+++ b/public/res/WELCOME.md
@@ -1,4 +1,3 @@
-
 Welcome to StackEdit!	{#welcome}
 =====================
 
@@ -219,7 +218,7 @@ $$
 > **NOTE:** When exporting, make sure you include MathJax to render mathematical expression correctly. Your page/template should include something like: 
 
 ```
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+<script type="text/javascript" src="https://stackedit.io/libs/MathJax/MathJax.js?config=TeX-AMS_HTML"></script>
 ```
 
 > **NOTE:** You can find more information:


### PR DESCRIPTION
I didn't find where in the code you set the default templates, so opened Settings→Services and copied from there.

Not sure if this actually affects StackEdit security — are the templates only used for exporting or also for preview?
Anyway, exporting with https URLs is a good thing for wherever the exported file will be used.

If only used for export, consider mathjax's [secure CDN URL](http://www.mathjax.org/resources/faqs/#problem-https) instead of stackedit.io — are you as sure stackedit.io will work 10 years from now as the fact mathjax's CDN will still work?
(admittedly their ugly https URL doesn't look so future-proof; but they claim it's "stable and safe to use")
