### PR TITLE
add publishDate to data when posting

### DIFF
--- a/public/res/helpers/googleHelper.js
+++ b/public/res/helpers/googleHelper.js
@@ -843,6 +843,9 @@ define([
                     title: title,
                     content: content
                 };
+                if (publishDate) {
+                  data.published = publishDate.toISOString();
+                }
                 var type = "POST";
                 // If it's an update
                 if(postId !== undefined) {


### PR DESCRIPTION
This fixes #330, in which posts with a future date are instantly published rather than scheduled for the future. Manually verified.

(note: `bower install` modified the `bower.json` file, which I assume is not something I should commit. I have it stashed, just in case)
