### PR TITLE
Changed bower urls from git to https

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,19 +18,18 @@
     "requirejs-text": "~2.0.10",
     "bootstrap-tour": "~0.7.1",
     "ace": "4bbe5346f2ae5ad35c0c47defa244ab27aedd451",
-    "pagedown-ace": "git@github.com:benweet/pagedown-ace.git#84d5e1b7ff233a1c8cafa9716e825228d275120c",
-    "pagedown-extra": "git@github.com:jmcmanus/pagedown-extra.git#bd0870e3e871e15bde1fa5a427e3e10028a09789",
-    "crel": "git@github.com:KoryNunn/crel.git#8dbda04b129fc0aec01a2a080d1cab26816e11c1",
-    "waitForImages": "git@github.com:alexanderdickson/waitForImages.git#~1.4.2",
-    "to-markdown": "git@github.com:benweet/to-markdown.git#jquery",
-    "Typo.js": "git@github.com:cfinke/Typo.js.git",
+    "pagedown-ace": "https://github.com/benweet/pagedown-ace.git#84d5e1b7ff233a1c8cafa9716e825228d275120c",
+    "pagedown-extra": "https://github.com/jmcmanus/pagedown-extra.git#bd0870e3e871e15bde1fa5a427e3e10028a09789",
+    "crel": "https://github.com/KoryNunn/crel.git#8dbda04b129fc0aec01a2a080d1cab26816e11c1",
+    "waitForImages": "https://github.com/alexanderdickson/waitForImages.git#~1.4.2",
+    "to-markdown": "https://github.com/benweet/to-markdown.git#jquery",
+    "Typo.js": "https://github.com/cfinke/Typo.js.git",
     "xregexp": "d06eff50f87d81d2dd3afc1e854784c38b17bcc4",
-    "yaml.js": "git@github.com:jeremyfa/yaml.js.git#~0.1.4",
-    "lz-string": "git@github.com:pieroxy/lz-string.git"
+    "yaml.js": "https://github.com/jeremyfa/yaml.js.git#~0.1.4",
+    "lz-string": "https://github.com/pieroxy/lz-string.git"
   },
   "resolutions": {
     "jquery": "2.0.3",
-    "bootstrap": "v3.0.0",
-    "pagedown-extra": "bd0870e3e871e15bde1fa5a427e3e10028a09789"
+    "bootstrap": "v3.0.0"
   }
 }


### PR DESCRIPTION
I was getting errors when I ran `bower install jspdf` because I don't have a SSH key associated with my github account. Changing the urls to the https protocol solved that and allows those without a github account to use the bower file as well.

Bower automatically removed the `pagedown-extra` resolution. Not sure if that matters.
