### PR TITLE
intuitive accordions in settings > extensions

### DIFF
--- a/public/res/styles/main.less
+++ b/public/res/styles/main.less
@@ -827,10 +827,19 @@ a {
 	}
 	
 	.accordion-heading {
-		padding: 12px 15px;
 		.checkbox {
-			margin-top: 0;
+			margin-top: 12px;
 			margin-bottom: 0;
+		}
+	}
+
+	.accordion-toggle {
+		display: block;
+		width: 80%;
+		padding: 12px 15px;
+		text-decoration: none;
+		&:after {
+			content: " ▼";
 		}
 	}
 	


### PR DESCRIPTION
After reading [sualeh's comment](https://github.com/benweet/stackedit/issues/137#issuecomment-26301268) on #137, I realized that I had had the same experience when I first started using StackEdit (not knowing that each extension in settings > extensions was an accordion dropdown with more options):

> I don't see any place to paste code into Settings->Extension->User Custom. It is just a checkbox. In any case, I think adding in custom CSS should be made even easier than that, for users that are not very technical.

This commit is an attempt to make the accordions more intuitive.
