### PR TITLE
Remove margin-bottom on nested lists

### DIFF
--- a/public/res-min/themes/default.css
+++ b/public/res-min/themes/default.css
@@ -1209,7 +1209,7 @@ table caption+thead tr:first-child th,table caption+thead tr:first-child td,tabl
 table tbody+tbody{border-top:2px solid #dddddd}
 blockquote{border-left-width:10px;background-color:rgba(102,128,153,0.05);border-top-right-radius:5px;border-bottom-right-radius:5px;padding:15px 20px}blockquote p{margin-bottom:15px;font-size:14px;line-height:1.428571429}
 blockquote ul:last-child,blockquote ol:last-child{margin-bottom:0}
-ul,ol{margin-bottom:15px}ul ul,ol ul,ul ol,ol ol{margin-bottom:15px}
+ul,ol{margin-bottom:15px}
 kbd{padding:0.1em 0.6em;border:1px solid rgba(22,32,41,0.25);-webkit-box-shadow:0 1px 0 rgba(22,32,41,0.25);box-shadow:0 1px 0 rgba(22,32,41,0.25);font-size:11px;font-family:Arial,Helvetica,sans-serif;background-color:#fff;color:#333;border-radius:3px;display:inline-block;margin:0 0.1em;white-space:nowrap}
 .toc ul{list-style-type:none;margin-bottom:5px}
 .footnote{vertical-align:top;position:relative;top:-0.5em;font-size:0.8em}


### PR DESCRIPTION
Nested lists should not have margin-bottom, it breaks the flows of the outer list content.
This is also aligned with how GitHub shows nested lists.

Possible to move the code at the beginning of the line to it's original declaration at line 79 as well:

```
ul,ol{margin-bottom:15px}
```

Before:
![before](https://cloud.githubusercontent.com/assets/480469/3659727/716182f8-11b0-11e4-8713-6ddbbf2af6e6.PNG)

After:
![after](https://cloud.githubusercontent.com/assets/480469/3659732/7b9f74a0-11b0-11e4-9680-3bc5d69874bc.PNG)

GitHub:
![github](https://cloud.githubusercontent.com/assets/480469/3659735/83b0d800-11b0-11e4-8dad-9dd85a7a1fec.PNG)
