### PR TITLE
fixed outdated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
-# Dockerfile for StackEdit
-
-FROM shykes/nodejs
+FROM debian:jessie
 
 RUN apt-get update
-RUN apt-get upgrade
-
-RUN apt-get install -y git-core
-
+RUN apt-get upgrade -yq
+RUN apt-get install -yq git nodejs-legacy npm
 RUN git clone https://github.com/benweet/stackedit.git
 
-RUN (cd /stackedit/ && npm install)
-EXPOSE 3000
+WORKDIR stackedit
+RUN npm install
+RUN node_modules/bower/bin/bower install --allow-root --production --config.interactive=false
+CMD nodejs server.js
 
-CMD (cd /stackedit/ && node server.js)
+EXPOSE 3000


### PR DESCRIPTION
fixes #531

I tried the initial 'official' nodejs image but ran into problems. I then used jessie because wheezy didn't have npm or something. I also used `nodejs-legacy` rather than `nodejs` because it provides a `node` binary rather than `nodejs` which lead to problems during `npm install`. Bower also needed `--allow-root`, but that's not a problem for a container, is it.
