### PR TITLE
Speedup gulp build by 30%

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -37,12 +37,13 @@ gulp.task('constants', function() {
 
 gulp.task('jshint', function() {
 	return gulp.src([
-		'./**/*.js',
-		'!./node_modules/**/*.js',
-		'!./public/libs/**/*.js',
-		'!./public/res/libs/**/*.js',
-		'!./public/res/bower-libs/**/*.js',
-		'!./public/res-min/**/*.js'
+		'./*.js',
+		'./app/**/*.js',
+		'./public/res/classes/**/*.js',
+		'./public/res/extensions/**/*.js',
+		'./public/res/helpers/**/*.js',
+		'./public/res/providers/**/*.js',
+		'./public/res/*.js'
 	])
 		.pipe(jshint())
 		.pipe(jshint.reporter('default'))


### PR DESCRIPTION
Avoid glob negations with gulp will reduce running time for `gulp jshint` from 13s to 3.5s

Also this brings down total time of build (running `gulp`) from 33s to 23s

This will improve gulp build times by 30%, and references issue #544 
