### PR TITLE
Update of stacktrace dependency, gives payload optimization

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "jgrowl": "~1.2.10",
     "google-code-prettify": "~1.0.0",
     "FileSaver": "*",
-    "stacktrace": "~0.5.3",
+    "stacktrace": "~0.6.2",
     "requirejs-text": "~2.0.10",
     "bootstrap-tour": "~0.7.1",
     "pagedown-extra": "https://github.com/jmcmanus/pagedown-extra.git#4484dd6696c82f1880b264bd610947f6f1cbdfb6",


### PR DESCRIPTION
the recent version excludes /test directory which contained a giant jar file. This reduces size of bower-libs/stacktrace folder
from 7MB to ~150KB

See https://github.com/stacktracejs/stacktrace.js/pull/84

This also references #544 since we have less payload to build and deploy (although I could not notice a speed reference on this particular update)
