### PR TITLE
use ?debug parameter more flexible

### DIFF
--- a/public/res/logger.js
+++ b/public/res/logger.js
@@ -1,5 +1,4 @@
 define([], function () {
-    
     // Defines the logger object
     var logger = {
         log: function () {},
@@ -7,7 +6,6 @@ define([], function () {
         warn: function () {},
         error: function () {}
     };
-    
     // We can run StackEdit with http://.../?console to print logs in the console
-    return (/(\?|&)console($|&)/).test(location.search) ? console : logger;
+    return (/(\?|&)console(=|$|&)/).test(location.search) ? console : logger;
 });

--- a/views/editor.html
+++ b/views/editor.html
@@ -20,7 +20,7 @@
         <script>
             // Use ?debug to serve original JavaScript files instead of minified
             window.baseDir = 'res';
-            if (!/(\?|&)debug($|&)/.test(location.search)) {
+            if (!/(\?|&)debug(=|$|&)/.test(location.search)) {
                 window.baseDir += '-min';
             }
             window.require = {

--- a/views/viewer.html
+++ b/views/viewer.html
@@ -14,7 +14,7 @@
         <script>
             // Use ?debug to serve original JavaScript files instead of minified
             window.baseDir = 'res';
-            if (!/(\?|&)debug($|&)/.test(location.search)) {
+            if (!/(\?|&)debug(=|$|&)/.test(location.search)) {
                 window.baseDir += '-min';
             }
             window.require = {


### PR DESCRIPTION
Before you could not specify '?debug=true', '?debug=1',
but only add debug with no assignment ('?debug')

This fixes so that anything is accepted as param. (also ?debug=false, though)
