### PR TITLE
Improve dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
-FROM debian:jessie
+# Pull base image.
+FROM node:0.10-onbuild
 
-RUN apt-get update
-RUN apt-get upgrade -yq
-RUN apt-get install -yq git nodejs-legacy npm
-RUN git clone https://github.com/benweet/stackedit.git
+# Node base will default the command to `node server.js`.
 
-WORKDIR stackedit
-RUN npm install
-RUN node_modules/bower/bin/bower install --allow-root --production --config.interactive=false
-CMD nodejs server.js
-
+# Expose port.
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image.
-FROM node:0.10-onbuild
+FROM node:0.11.14-onbuild
 
 # Node base will default the command to `node server.js`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image.
-FROM node:0.11.14-onbuild
+FROM node:0.12-onbuild
 
 # Node base will default the command to `node server.js`.
 


### PR DESCRIPTION
This significantly simplifies the dockerfile for stackedit by using [library/node](https://registry.hub.docker.com/u/library/node/) as its base.

This simplification works because `npm install` and `npm start` are called by the base image.

This will always create the container using the source code the dockerfile is "living with" and will not pull from git separately. Versioning is handled by specifying on dockerhub what git tagged versions should be made available.

To test I set up a [build repo on dockerhub](https://registry.hub.docker.com/u/library/node/) with several testing tags. If you wanted to set up an "official" stackedit build repo its pretty easy. Just setup the automatic builds as follows, where "Name" is the git tag to use code from and "Docker Tag Name" is the version name used by docker.

Type | Name | Dockerfile Location | Docker Tag Name
-------|---------|--------------------------|------------------------
Tag|master| / | latest
Tag|v4.3.2| / | v4.3.2
Tag|v4.3.1| / | v4.3.1

I believe this really is the best way to do this and should require virtually no future maintenance.