### PR TITLE
adds image upload support from clipboard (upload to github)

### DIFF
--- a/public/libs/github.js
+++ b/public/libs/github.js
@@ -352,22 +352,39 @@
       // -------
 
       this.postBlob = function(content, cb) {
-        if (typeof(content) === "string") {
+        if ((typeof(content) === "object") && (content.type === "image/png")) {
+          var tmp = content;
           content = {
-            "content": content,
-            "encoding": "utf-8"
+            "encoding": "base64",
+            "content": null
           };
+          var reader = new FileReader();
+          reader.onloadend = function(event) {
+              content.content = btoa(event.target.result);
+              _request("POST", repoPath + "/git/blobs", content, function(err, res) {
+                  if (err) return cb(err);
+                  cb(null, res.sha);
+              });
+              return;
+          }
+          reader.readAsBinaryString(tmp);
         } else {
-          	content = {
+          if (typeof(content) === "string") {
+            content = {
+              "content": content,
+              "encoding": "utf-8"
+            };
+          } else {
+            content = {
               "content": btoa(String.fromCharCode.apply(null, new Uint8Array(content))),
               "encoding": "base64"
             };
           }
-
-        _request("POST", repoPath + "/git/blobs", content, function(err, res) {
-          if (err) return cb(err);
-          cb(null, res.sha);
-        });
+          _request("POST", repoPath + "/git/blobs", content, function(err, res) {
+            if (err) return cb(err);
+            cb(null, res.sha);
+          });
+        }
       };
 
       // Update an existing tree adding a new blob object getting a tree SHA back

--- a/public/res/core.js
+++ b/public/res/core.js
@@ -129,6 +129,8 @@ define([
 		utils.setInputRadio("radio-settings-edit-mode", settings.editMode);
 		// Commit message
 		utils.setInputValue("#input-settings-publish-commit-msg", settings.commitMsg);
+		// Image Commit message
+		utils.setInputValue("#input-settings-publish-img-commit-msg", settings.imgCommitMsg);
 		// Markdown MIME type
 		utils.setInputValue("#input-settings-markdown-mime-type", settings.markdownMimeType);
 		// Gdrive multi-accounts
@@ -176,6 +178,8 @@ define([
 		newSettings.editMode = utils.getInputRadio("radio-settings-edit-mode");
 		// Commit message
 		newSettings.commitMsg = utils.getInputTextValue("#input-settings-publish-commit-msg", event);
+		// Image Commit message
+		newSettings.imgCommitMsg = utils.getInputTextValue("#input-settings-publish-img-commit-msg", event);
 		// Gdrive multi-accounts
 		newSettings.gdriveMultiAccount = utils.getInputIntValue("#input-settings-gdrive-multiaccount");
 		// Markdown MIME type

--- a/public/res/html/bodyEditor.html
+++ b/public/res/html/bodyEditor.html
@@ -897,6 +897,23 @@
 							</div>
 						</div>
 					</div>
+					<div class="form-group modal-publish-github">
+						<label class="col-sm-4 control-label"
+							for="input-publish-github-img-branch">Image Branch</label>
+						<div class="col-sm-7">
+							<input type="text" id="input-publish-github-img-branch"
+								placeholder="img-branch-name" class="form-control">
+						</div>
+					</div>
+					<div class="form-group modal-publish-github">
+						<label class="col-sm-4 control-label"
+							for="input-publish-img-folder">Image folder</label>
+						<div class="col-sm-7">
+							<input type="text" id="input-publish-img-folder"
+								placeholder="path/to/folder/" class="form-control">
+							<span class="help-block"> Path to Image Folder. </span>
+						</div>
+					</div>
 					<div class="collapse publish-custom-template-collapse">
 						<div class="form-group">
 							<div class="col-sm-4"></div>
@@ -1265,6 +1282,14 @@
 									for="input-settings-publish-commit-msg">GitHub commit message</label>
 								<div class="col-sm-7">
 									<input type="text" id="input-settings-publish-commit-msg"
+										class="form-control">
+								</div>
+							</div>
+							<div class="form-group">
+								<label class="col-sm-4 control-label"
+									for="input-settings-publish-img-commit-msg">GitHub Image commit message</label>
+								<div class="col-sm-7">
+									<input type="text" id="input-settings-publish-img-commit-msg"
 										class="form-control">
 								</div>
 							</div>

--- a/public/res/providers/githubProvider.js
+++ b/public/res/providers/githubProvider.js
@@ -30,11 +30,21 @@ define([
 		});
 	};
 
+	githubProvider.imgPublish = function(publishAttributes, frontMatter, title, content, callback) {
+		var commitMsg = settings.imgCommitMsg;
+		githubHelper.upload(publishAttributes.repository, publishAttributes.username, publishAttributes.imgBranch, publishAttributes.imgPath, content, commitMsg, function(err, username) {
+			publishAttributes.username = username;
+			callback(err);
+		});
+	};
+
 	githubProvider.newPublishAttributes = function(event) {
 		var publishAttributes = {};
 		publishAttributes.repository = utils.getInputTextValue("#input-publish-github-repo", event);
 		publishAttributes.branch = utils.getInputTextValue("#input-publish-github-branch", event);
 		publishAttributes.path = utils.getInputTextValue("#input-publish-file-path", event);
+		publishAttributes.imgFolder = utils.getInputTextValue("#input-publish-img-folder", event);
+		publishAttributes.imgBranch = utils.getInputTextValue("#input-publish-github-img-branch", event);
 		if(event.isPropagationStopped()) {
 			return undefined;
 		}

--- a/public/res/publisher.js
+++ b/public/res/publisher.js
@@ -212,7 +212,7 @@ define([
 			attributes.provider.imgPublish(attributes, publishFileDesc.frontMatter, "image", img, function() {
 				publishRunning = false;
 				eventMgr.onPublishRunning(false);
-				if (attributes.branch === "gh-pages") {
+				if (attributes.imgBranch === "gh-pages") {
 					cb("http://".concat(attributes.username, ".github.io/",
 						attributes.repository, "/", attributes.imgPath));
 				} else {

--- a/public/res/publisher.js
+++ b/public/res/publisher.js
@@ -183,6 +183,48 @@ define([
 		});
 	};
 
+	publisher.imgPublish = function(img, imgName, cb) {
+		if(publishRunning === true || isOffline === true) {
+			return;
+		}
+
+		if (img !== null && imgName !== null && imgName !== "") {
+
+			publishRunning = true;
+			eventMgr.onPublishRunning(true);
+
+			publishFileDesc = fileMgr.currentFile;
+			var list = _.values(publishFileDesc.publishLocations);
+			var attributes;
+			var i;
+			// get github attributes
+			for (i = 0; i < list.length; i++) {
+				if (list[i].provider.providerId === "github") {
+					attributes = list[i];
+				}
+			}
+			// add a / to image folder if missing
+			if (attributes.imgFolder.indexOf("/", attributes.imgFolder.length - 1) === -1) {
+				attributes.imgFolder = attributes.imgFolder.concat("/");
+			}
+			attributes.imgPath = attributes.imgFolder.concat(imgName);
+			attributes.format = "image";
+			attributes.provider.imgPublish(attributes, publishFileDesc.frontMatter, "image", img, function() {
+				publishRunning = false;
+				eventMgr.onPublishRunning(false);
+				if (attributes.branch === "gh-pages") {
+					cb("http://".concat(attributes.username, ".github.io/",
+						attributes.repository, "/", attributes.imgPath));
+				} else {
+					cb("https://raw.githubusercontent.com/".concat(attributes.username, "/",
+						attributes.repository, "/", attributes.branch, "/", attributes.imgPath));
+				}
+			});
+		} else {
+			console.log("no image or name given.\n");
+		}
+	};
+
 	// Generate a publishIndex associated to a file and store publishAttributes
 	function createPublishIndex(fileDesc, publishAttributes) {
 		var publishIndex;

--- a/public/res/settings.js
+++ b/public/res/settings.js
@@ -14,6 +14,7 @@ define([
 		cursorFocusRatio: 0.5,
 		defaultContent: "\n\n\n> Written with [StackEdit](" + constants.MAIN_URL + ").",
 		commitMsg: "Published with " + constants.MAIN_URL,
+		imgCommitMsg: "Image upload.",
 		conflictMode: 'merge',
 		markdownMimeType: 'text/plain',
 		gdriveMultiAccount: 1,


### PR DESCRIPTION
on paste event (strg-v) the clipboard is checked for a image, if one is
found the user will be prompt for the image name with a pre entered name
(img_[unixtimestamp].png). the user can then enter either a name, accept
the given name, or abort (in which case nothing will happen).
image folder and branch are asked at github publish settings, commit
message can be configured in settings (below github commit message
settings), default commit message is 'Image upload.'
a missing / on the end of the given folder will be added if not given.

after a upload to github the raw.githubusercontent.com link will be
inserted. for example:
![](https://raw.githubusercontent.com/username/repo/imgBranch/imgFolder/imgName)

if the given image branch is gh-pages the github.io link will be
inserted instead. for example:
![](http://username.github.io/repo/imageFolder/imgName)
