### PR TITLE
stackedit auto-download given file on startup

### DIFF
--- a/public/res/providers/downloadProvider.js
+++ b/public/res/providers/downloadProvider.js
@@ -3,10 +3,11 @@ define([
 	"constants",
 	"eventMgr",
 	"utils",
+	"fileSystem",
 	"fileMgr",
 	"classes/Provider",
 	"classes/AsyncTask"
-], function($, constants, eventMgr, utils, fileMgr, Provider, AsyncTask) {
+], function($, constants, eventMgr, utils, fileSystem, fileMgr, Provider, AsyncTask) {
 
 	var downloadProvider = new Provider("download");
 	downloadProvider.viewerSharingAttributes = [
@@ -62,6 +63,27 @@ define([
 				});
 			}
 		});
+		if (location.hash) {
+			var hash = JSON.parse(location.hash.replace("#", ""));
+			if (hash.type === "download") {
+				var fileDesc = null;
+				utils.retrieveIndexArray("file.list").forEach(function(fileIndex) {
+					if (fileSystem[fileIndex].title === hash.importParameters.title) {
+						fileDesc = fileSystem[fileIndex];
+						return;
+					}
+				});
+
+				downloadProvider.importPublic(hash.importParameters, function(undefined, title, content) {
+					if (fileDesc === null) {
+						fileDesc = fileMgr.createFile(hash.importParameters.title, content);
+					}
+					eventMgr.onContentChanged(fileDesc, content);
+
+					fileMgr.selectFile(fileDesc);
+				});
+			}
+		}
 	});
 
 	return downloadProvider;


### PR DESCRIPTION
adds the opportunity to start stackedit with a url and title
so that it starts and loads a given file. This is enabled by appending
json formated text to the link. here is a example:

stackedit.io/editor#{"type":"download","importParameters":{"url": ... }}

json string after the #:
{
        "type"             : "download",
        "importParameters" :
        {
                "url"   : "http://url/to/my/file.md",
                "title" : "myAwesomeFile.md",
        }
}

"type" is the given provider type u want to use, someone could add
other providers if they like. if type "download" is given a fileDesc with
the given "importParameters" will be created and the file content will
be directly downloaded from the given url.
the title will be checked against all other loaded documents, if a file
with the same title already exists it's content will be overwritten by
the downloaded content.
- url   : the url where the file content can be downloaded
- title : the title which will be used
