### PR TITLE
Fix MathJax link for webpage export

### DIFF
--- a/public/res/settings.js
+++ b/public/res/settings.js
@@ -28,7 +28,7 @@ define([
 			'<meta name="viewport" content="width=device-width, initial-scale=1.0">',
 			'<title><%= documentTitle %></title>',
 			'<link rel="stylesheet" href="' + constants.MAIN_URL + 'res-min/themes/base.css" />',
-			'<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>',
+			'<script src="https://cdn.mathjax.org/mathjax/​latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>',
 			'</head>',
 			'<body><div class="container"><%= documentHTML %></div></body>',
 			'</html>'


### PR DESCRIPTION
Had problems exporting because of [Math Processing Error] all over the page. 

Apparently no browser could download the necessary fonts. Changing this line fixed it for me. 

This was barely tested because my web programming skills are almost non-existent. I am creating a pull request because it took me a while to find the culprit and this way maybe I'll save somebody a little time.

This is my first attempt at contributing to a project so if I am doing anything wrong, please let me know.