### PR TITLE
Optimization in HTML Sanitizer

### DIFF
--- a/public/res/extensions/htmlSanitizer.js
+++ b/public/res/extensions/htmlSanitizer.js
@@ -19,9 +19,8 @@ define([
 				htmlParser(sectionHtml, htmlSanitizeWriter(buf, function(uri, isImage) {
 					return !/^unsafe/.test(sanitizeUri(uri, isImage));
 				}));
-				buf.push('<div class="se-preview-section-delimiter"></div>');
 			});
-			return buf.slice(0, -1).join('');
+			return buf.join('<div class="se-preview-section-delimiter"></div>');
 		});
 	};
 


### PR DESCRIPTION
Why first push delimiters in only to remove the last.

Instead, by this commit, just join in the end with the desired delimiter.