### PR TITLE
Updates to developer guide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "0.10"
+before_install: npm install -g gulp-cli bower
+
+# don't run tests, since Stackedit have none. 
+# 'true' is a unix command which returns 0
+script: true
+

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -580,14 +580,9 @@ myExtension.onMessage = function(message) {
 
 ----------
 
-#### ACE events
 
-- **`onAceCreated(aceEditor)`**
 
-    The ACE editor has just been created.
-    - `aceEditor`: the ACE editor object.
 
-    > Triggered by the `core` module.
 
 
 

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -15,19 +15,19 @@ Getting started
 
 - Download development tools:
 
-		npm install
+        npm install
 
 - Download dependencies and build:
 
-		npm run setup
+        npm run setup
 
 - Serve **StackEdit** at `http://localhost:80/`:
 
-		npm run server
+        npm run server
 
  Run **StackEdit** in debug mode (no application cache, serve original files instead of minified):
 
-		http://localhost/?debug
+        http://localhost/?debug
 
 ### Add new dependencies
 
@@ -35,15 +35,15 @@ Getting started
 
 - Install new dependencies using [Bower][7]:
 
-		bower install <library> --save
+        bower install <library> --save
 
 - Add the new dependency to [RequireJS][8] configuration file (`main.js`):
 
-		gulp bower-requirejs
+        gulp bower-requirejs
 
 ### Build/minify
 
-	gulp
+    gulp
 
 ### Deploy
 
@@ -205,9 +205,9 @@ A `publishAttributes` object is an object that describes a publish location. Att
 - `publishIndex`: the unique string index of the publish location.
 - `provider`: the [`provider`][38] module that handles the publish location.
 - `format`: the publishing format for the publish location. It can be:
-	- `markdown` for Markdown format.
-	- `html` for HTML format.
-	- `template` for template format.
+    - `markdown` for Markdown format.
+    - `html` for HTML format.
+    - `template` for template format.
 
 
 ----------

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -17,13 +17,12 @@ Getting started
 
         npm install
 
-- Download dependencies and build:
+Download dependencies and build (done automatically after `npm install`)
 
-        npm run setup
 
 - Serve **StackEdit** at `http://localhost:80/`:
 
-        npm run server
+        npm start
 
  Run **StackEdit** in debug mode (no application cache, serve original files instead of minified):
 

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -502,14 +502,13 @@ myExtension.onMessage = function(message) {
     The layout has just been created.
     - `layout`: the layout object of the UI Layout library.
 
-    > Triggered by the `core` module.
+    > Triggered by the `layout` module.
 
-- **`onLayoutResize(paneName)`**
+- **`onLayoutResize()`**
 
     One pane of the layout has been resized.
-    - `paneName`: the name of the resized layout pane.
 
-    > Triggered by the `core` module.
+    > Triggered by the `layout` module.
 
 - **`onCreateButton()`**
 

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -577,13 +577,59 @@ myExtension.onMessage = function(message) {
 
     > Triggered by the `yamlFrontMatterParser` extension.
 
-
 ----------
 
+#### Internal PageDown editor events
+`Markdown.Editor.js` exposes some hooks, which Stackedit uses internally to render
+text, calculate Scolling positions, and more.
+
+- **`onPreviewRefresh`**
+    Called with no arguments after the preview has been refreshed
+    > Triggered by the `Markdown.Editor` module.
 
 
+- **`postBlockquoteCreation(selection)`**
+    called with the user's selection *after* the blockquote was created; should
+    return the actual to-be-inserted text
+    > Triggered by the `Markdown.Editor` module.
+
+- **`insertImageDialog(callback(imageUrl){})`**
+    called with one parameter: a callback to be called with the URL of the image.
+    If the application creates its own image insertion dialog, this hook should
+    return true, and the callback should be called with the chosen image url
+    (or null if the user cancelled). If this hook returns false, the default
+    dialog will be used.
+    > Triggered by the `Markdown.Editor` module.
+
+- **`insertLinkDialog`**
+    Custom hook added by Stackedit. See `insertImageDialog` above.
+    > Triggered by the `Markdown.Editor` module.
 
 
+----------
+#### Internal PageDown converter events
+`Markdown.Converter.js` exposes some hooks, which Stackedit uses internally
+
+- **`preConversion(text)`**
+
+    called with the orignal text as given to makeHtml. The result of this
+    plugin hook is the actual markdown source that will be cooked
+
+    > Triggered by the `Markdown.Converter` module.
+
+- **`postNormalization(text)`**
+
+    called with the text once all normalizations have been completed (tabs to
+    spaces, line endings, etc.), but before any conversions have been made
+
+    > Triggered by the `Markdown.Converter` module.
+
+- **`postConversion(html)`**
+
+    called with the final cooked HTML code. The result of this plugin hook is
+    the actual output of makeHtml
+
+    > Triggered by the `Markdown.Converter` module.
 
 
 > Written with [StackEdit](https://stackedit.io/).

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -17,15 +17,15 @@ Getting started
 
 		npm install
 
-- Download dependencies:
+- Download dependencies and build:
 
-		bower install
+		npm run setup
 
-- Serve **StackEdit** at `http://localhost/`:
+- Serve **StackEdit** at `http://localhost:80/`:
 
-		(export PORT=80 && node server.js)
-		
-- Run **StackEdit** in debug mode (no application cache, serve original files instead of minified):
+		npm run server
+
+ Run **StackEdit** in debug mode (no application cache, serve original files instead of minified):
 
 		http://localhost/?debug
 
@@ -44,7 +44,7 @@ Getting started
 ### Build/minify
 
 	gulp
-	
+
 ### Deploy
 
 - on Heroku:
@@ -247,9 +247,9 @@ myExtension.onMessage = function(message) {
 - **`onReady()`**
 
     All the modules are loaded and the DOM is ready.
-    
+
     > Triggered by the `core` module.
-    
+
     > This is preferred over [jQuery's `.ready()`][39] because it ensures that all modules have been loaded by RequireJS.
 
 - **`onMessage(message)`**
@@ -266,32 +266,32 @@ myExtension.onMessage = function(message) {
 
     The off-line status has changed.
     - `isOffline`: the off-line status.
-    
+
     >  Triggered by the `core` module.
 
 - **`onUserActive()`**
 
     The user has just moved the mouse or pressed the keyboard.
-    
+
     > Triggered by the `core` module.
 
 - **`onAsyncRunning(isRunning)`**
 
     Some asynchronous tasks have just started or stopped.
     - `isRunning`: true if started, false if stopped.
-    
+
     > Triggered by the `AsyncTask` module.
 
 - **`onPeriodicRun()`**
 
     A hook that is called periodically (every 1 second if user is active).
-    
+
     > Triggered by the `core` module.
 
 - **`onLoadSettings()`**
 
     A hook that is called when the settings dialog has to be refreshed. Every `Extension` module that has configuration inputs in the settings dialog has to implement a listener for this event.
-    
+
     > Triggered by the `core` module. Only `Extension` modules can handle this event.
 
 - **`onSaveSettings(newConfig, event)`**
@@ -299,15 +299,15 @@ myExtension.onMessage = function(message) {
     A hook that is called when the settings dialog has to be validated. Every `Extension` module that has configuration inputs in the settings dialog has to implement a listener for this event.
     - `newConfig`: the new configuration object, deduced from the settings dialog inputs.
     - `event`: the submit event object. `stopPropagation` has to be called in case of an error when parsing settings dialog inputs.
-    
+
     > Triggered by the `core` module. Only `Extension` modules can handle this event.
 
 - **`onInit()`**
 
     A hook allowing enabled extensions to initialize.
-    
+
     > Triggered by the `eventMgr` module. Only `Extension` modules can handle this event.
-    
+
     > This event is triggered before `onReady` event and just after the `config` and `enabled` extensions properties have been set by the `eventMgr`.
 
 
@@ -319,7 +319,7 @@ myExtension.onMessage = function(message) {
 
     The `fileMgr` module has been created.
     - `fileMgr`: the `fileMgr` module.
-    
+
     > Triggered by the `fileMgr` module.
 
 
@@ -327,21 +327,21 @@ myExtension.onMessage = function(message) {
 
     The `synchronizer` module has been created.
     - `synchronizer`: the `synchronizer` module.
-    
+
     > Triggered by the `synchronizer` module.
 
 - **`onPublisherCreated(publisher)`**
 
     The `publisher` module has been created.
     - `publisher`: the `publisher` module.
-    
+
     > Triggered by the `publisher` module.
 
-- **`onEventMgrCreated()`**
+- **`onEventMgrCreated(eventMgr)`**
 
     The `eventMgr` module has been created.
     - `eventMgr`: the `eventMgr` module.
-    
+
     > Triggered by the `eventMgr` module.
 
 
@@ -353,42 +353,42 @@ myExtension.onMessage = function(message) {
 
     A [`FileDescriptor`][41] object has been created.
     - `fileDesc`: the [`FileDescriptor`][42] object.
-    
+
     > Triggered by the `fileMgr` module.
 
 - **`onFileDeleted(fileDesc)`**
 
     A [`FileDescriptor`][43] object has been removed from the `fileSystem` module.
     - `fileDesc`: the [`FileDescriptor`][44] object.
-    
+
     > Triggered by the `fileMgr` module.
 
 - **`onFileSelected(fileDesc)`**
 
     A [`FileDescriptor`][45] object has been selected.
     - `fileDesc`: the [`FileDescriptor`][46] object.
-    
+
     > Triggered by the `fileMgr` module. This event is triggered before `onFileClosed` (if another document is open) and `onFileOpen` events.
 
 - **`onFileClosed(fileDesc)`**
 
     The current [`FileDescriptor`][47] object is about to be detached from the editor.
     - `fileDesc`: the [`FileDescriptor`][48] object.
-    
+
     > Triggered by the `fileMgr` module. This event is triggered after `onFileSelected` event and before `onFileClosed` event.
 
 - **`onFileOpen(fileDesc)`**
 
     The selected [`FileDescriptor`][49] object has been attached to the editor.
     - `fileDesc`: the [`FileDescriptor`][50] object.
-    
+
     > Triggered by the `fileMgr` module. This event is triggered after `onFileSelected` and `onFileClosed` (if another document is open) events.
 
 - **`onContentChanged(fileDesc)`**
 
     The content of a [`FileDescriptor`][51] object has been modified.
     - `fileDesc`: the [`FileDescriptor`][52] object.
-    
+
 - **`onTitleChanged(fileDesc)`**
 
     The content of a [`FileDescriptor`][53] object has been modified.
@@ -407,27 +407,27 @@ myExtension.onMessage = function(message) {
 
     A synchronization job has just started or stopped.
     - `isRunning`: true if started, false if stopped.
-    
+
     > Triggered by the `synchronizer` module.
-    
+
     > A synchronization job is the action to download and upload all detected changes for all sync locations of all documents.
 
 - **`onSyncSuccess()`**
 
     A synchronization job has successfully finished.
-    
+
     > Triggered by the `synchronizer` module.
-    
+
     > A synchronization job is the action to download and upload all detected changes for all sync locations of all documents.
-    
+
 - **`onSyncImportSuccess(fileDescList, provider)`**
 
     The import of documents has successfully finished.
     - `fileDescList`: the list of [`FileDescriptor`][55] objects that have been created.
     - `provider`: the [`provider`][56] module that handled the import.
-    
+
     > Triggered by the [`provider`][57] module that handled the import.
-    
+
     > An import is the action to download multiple files and to create, for each, one [`FileDescriptor`][55] objects with one sync location.
 
 - **`onSyncExportSuccess(fileDesc, syncAttributes)`**
@@ -435,9 +435,9 @@ myExtension.onMessage = function(message) {
     The export of one document has successfully finished.
     - `fileDesc`: the [`FileDescriptor`][58] object that has been exported.
     - `syncAttributes`: the descriptor object of the new sync location.
-    
+
     > Triggered by the `synchronizer` module.
-    
+
     > An export is the action to upload one file and to create one new sync location associated with one existing `FileDescriptor`][55] object.
 
 - **`onSyncRemoved(fileDesc, syncAttributes)`**
@@ -445,7 +445,7 @@ myExtension.onMessage = function(message) {
     A sync location has been removed from a [`FileDescriptor`][59] object.
     - `fileDesc`: the [`FileDescriptor`][60] object.
     - `syncAttributes`: the descriptor object of the removed sync location.
-    
+
 
 ----------
 
@@ -455,26 +455,26 @@ myExtension.onMessage = function(message) {
 
     A document publication job has just started or stopped.
     - `isRunning`: true if started, false if stopped.
-    
+
     > Triggered by the `publisher` module.
-    
+
     > A publication job is the action to upload changes on multiple publish locations associated with one `FileDescriptor`][55] object.
 
 - **`onPublishSuccess(fileDesc)`**
 
     A document publication job has successfully finished.
     - `fileDesc`: the [`FileDescriptor`][60] object that has been published.
-    
+
     > Triggered by the `publisher` module.
-    
+
     > A publication job is the action to upload changes on multiple publish locations associated with one `FileDescriptor`][55] object.
-    
+
 - **`onNewPublishSuccess(fileDesc, publishAttributes)`**
 
     A new publish location has been successfully created.
     - `fileDesc`: the [`FileDescriptor`][60] object that has been published.
     - `publishAttributes`: the descriptor object of the new publish location.
-    
+
     > Triggered by the `publisher` module.
 
 - **`onPublishRemoved(fileDesc, publishAttributes)`**
@@ -482,7 +482,7 @@ myExtension.onMessage = function(message) {
     A publish location has been removed from a [`FileDescriptor`][59] object.
     - `fileDesc`: the [`FileDescriptor`][60] object.
     - `publishAttributes`: the descriptor object of the removed publish location.
-    
+
     > Triggered by the `publisher` module.
 
 
@@ -494,23 +494,23 @@ myExtension.onMessage = function(message) {
 
     The layout is about to be configured.
     - `layoutConfig`: the configuration object of the UI Layout library.
-    
+
     > Triggered by the `core` module.
 
 - **`onLayoutCreated(layout)`**
 
     The layout has just been created.
     - `layout`: the layout object of the UI Layout library.
-    
+
     > Triggered by the `core` module.
 
 - **`onLayoutResize(paneName)`**
 
     One pane of the layout has been resized.
     - `paneName`: the name of the resized layout pane.
-    
+
     > Triggered by the `core` module.
-    
+
 - **`onCreateButton()`**
 
     Allows extensions to add their own buttons in the navigation bar. Implemented listeners have to return an HTML button element. For example:
@@ -522,19 +522,19 @@ myExtension.onMessage = function(message) {
             });
             return button[0];
         };
-    
+
     > Triggered by the `eventMgr` module. Only `Extension` modules can handle this event.
 
 - **`onCreateEditorButton()`**
 
     Allows extensions to add their own buttons in the side bar. Implemented listeners have to return an HTML button element. See `onCreateButton` for a concrete example.
-    
+
     > Triggered by the `eventMgr` module. Only `Extension` modules can handle this event.
 
 - **`onCreatePreviewButton()`**
 
     Allows extensions to add their own buttons over the preview. Implemented listeners have to return an HTML button element. See `onCreateButton` for a concrete example.
-    
+
     > Triggered by the `eventMgr` module. Only `Extension` modules can handle this event.
 
 
@@ -546,16 +546,16 @@ myExtension.onMessage = function(message) {
 
     The Pagedown editor is about to be created.
     - `editor`: the Pagedown editor object before `run` has been called.
-    
+
     > Triggered by the `core` module.
     
 - **`onAsyncPreview(callback)`**
 
     Called after Pagedown's synchronous rendering to trigger extra asynchronous rendering (such as MathJax). Implemented listeners have to call the callback parameter after processing in order other `onAsyncPreview` listeners to run.
     - `callback`: the callback to call at the end of the asynchronous processing.
-    
+
     > Triggered by the `eventMgr` module. Only `Extension` modules can handle this event.
-    
+
 - **`onPreviewFinished(html)`**
 
     Called after every `onAsyncPreview` listeners have been called.
@@ -567,14 +567,14 @@ myExtension.onMessage = function(message) {
     - `sectionList`: the list of section objects. Each section object contains:
         - `text`: the markdown substring contained in the section.
         - `textWithDelimiter`: the text with an added delimiter.
-    
+
     > Triggered by the `markdownSectionParser` extension.
 
 - **`onMarkdownTrim(offset)`**
 
     The Markdown has been left trimmed by a certain number of character.
     - `offset`: the number of characters that have been removed.
-    
+
     > Triggered by the `yamlFrontMatterParser` extension.
 
 
@@ -586,7 +586,7 @@ myExtension.onMessage = function(message) {
 
     The ACE editor has just been created.
     - `aceEditor`: the ACE editor object.
-    
+
     > Triggered by the `core` module.
 
 

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -523,12 +523,6 @@ myExtension.onMessage = function(message) {
 
     > Triggered by the `eventMgr` module. Only `Extension` modules can handle this event.
 
-- **`onCreateEditorButton()`**
-
-    Allows extensions to add their own buttons in the side bar. Implemented listeners have to return an HTML button element. See `onCreateButton` for a concrete example.
-
-    > Triggered by the `eventMgr` module. Only `Extension` modules can handle this event.
-
 - **`onCreatePreviewButton()`**
 
     Allows extensions to add their own buttons over the preview. Implemented listeners have to return an HTML button element. See `onCreateButton` for a concrete example.
@@ -546,7 +540,7 @@ myExtension.onMessage = function(message) {
     - `editor`: the Pagedown editor object before `run` has been called.
 
     > Triggered by the `core` module.
-    
+
 - **`onAsyncPreview(callback)`**
 
     Called after Pagedown's synchronous rendering to trigger extra asynchronous rendering (such as MathJax). Implemented listeners have to call the callback parameter after processing in order other `onAsyncPreview` listeners to run.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "event-stream": "^3.1.7"
   },
   "scripts": {
+    "postinstall": "bower install && bower prune && gulp",
+    "start": "PORT=80 node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
-  [x] Fixed documentation for `onLayoutResize()`
-  [x] Convert all tabs to spaces for consistency
-  [x] Removed section about ACE editor events
-  [x] Removed nonexisting hook `onCreateEditorButton` 
-  [x] Update documentation for `eventMgr` event
-  [x] Add description of the PageDown hooks which are
     extensively used by Stackedit  for partial rendering, scroll sync, TOC and
     more.
- [x] Changed setup description to include discoverable tasks added in #598
