### PR TITLE
Timestamps for comments.

### DIFF
--- a/public/res/extensions/comments.js
+++ b/public/res/extensions/comments.js
@@ -368,11 +368,13 @@ define([
 				}
 
 				var discussion = context.getDiscussion();
+				var timestamp = Date.now();
 				context.$contentInputElt.val('');
 				closeCurrentPopover();
 
 				discussion.commentList = discussion.commentList || [];
 				discussion.commentList.push({
+					created_at: timestamp,
 					author: author,
 					content: content
 				});
@@ -384,6 +386,7 @@ define([
 						discussionIndex = utils.id();
 					} while(_.has(discussionList, discussionIndex));
 					discussion.discussionIndex = discussionIndex;
+					discussion.created_at = timestamp;
 					discussionList[discussionIndex] = discussion;
 					context.fileDesc.discussionList = discussionList; // Write discussionList in localStorage
 					eventMgr.onDiscussionCreated(context.fileDesc, discussion);


### PR DESCRIPTION
Fixes issue #749 
- [x] register timestamp for each comment
- [x] register timestamp for each discussion

Currently not displaying the timestamps, so it's meant for API consumption in 
synchronizers/publishers. (since that's what I currently need)
