### PR TITLE
remove space after nested lists

### DIFF
--- a/public/res/styles/base.less
+++ b/public/res/styles/base.less
@@ -321,9 +321,6 @@ blockquote {
 
 ul,ol {
 	margin-bottom: @p-margin;
-	ul,ol {
-		margin-bottom: @p-margin;
-	}
 }
 
 kbd {


### PR DESCRIPTION
This markdown:

``` md
 - personal/situational theories: leadership ability depends on environment
 - Humanistic theories
     - Abraham Maslow (psychologist)
 - behavioral research: rewards & punishments, controlling people instead of leading them
     - Ohio State University's dimensional studies
         - two dimensions: initiation of structure and consideration
     - Kurt Lewin’s group studies
```

looks like this on StackEdit:
![screenshot-stackedit io 2015-04-11 08-59-47](https://cloud.githubusercontent.com/assets/1326984/7102059/4a586aa8-e029-11e4-8f69-5e542fdfa126.png)

This commit removes the inconsistent spacing after the 3rd and 6th `<li>`s.
