### PR TITLE
Add nomnoml rendering feature

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,8 @@
     "flowchart": "https://github.com/adrai/flowchart.js.git#751717d3db6437def9a5f8b1cb73e8bb81b5833a",
     "monetizejs": "~0.2.0",
     "MathJax": "~2.5.0",
-    "alertify.js": "https://github.com/fabien-d/alertify.js.git#fc2e06fa39873363dda199204b8544119ab060bf"
+    "alertify.js": "https://github.com/fabien-d/alertify.js.git#fc2e06fa39873363dda199204b8544119ab060bf",
+    "nomnoml": "skanaar/nomnoml#d62ec1ddcb8fa3226c9147c4132fd42f9ef8de5b"
   },
   "main": [
     "/public/res/main.js",

--- a/public/res/extensions/umlDiagrams.js
+++ b/public/res/extensions/umlDiagrams.js
@@ -7,8 +7,9 @@ define([
 	"text!html/umlDiagramsSettingsBlock.html",
 	'crel',
 	'Diagram',
-	'flow-chart'
-], function($, _, utils, logger, Extension, umlDiagramsSettingsBlockHTML, crel, Diagram, flowChart) {
+	'flow-chart',
+	'nomnoml'
+], function($, _, utils, logger, Extension, umlDiagramsSettingsBlockHTML, crel, Diagram, flowChart, nomnoml) {
 
 	var umlDiagrams = new Extension("umlDiagrams", "UML Diagrams", true);
 	umlDiagrams.settingsBlock = umlDiagramsSettingsBlockHTML;
@@ -57,6 +58,24 @@ define([
 					});
 					preElt.parentNode.replaceChild(containerElt, preElt);
 					chart.drawSVG(containerElt, JSON.parse(umlDiagrams.config.flowchartOptions));
+				}
+				catch(e) {
+				}
+			});
+			_.each(previewContentsElt.querySelectorAll('.prettyprint > .language-nomnoml'), function(elt) {
+				try {
+					var themeFills = '#fill: #eee; #f8f8f8\n';	// TODO: Create this from theme palette instead.
+					var preElt = elt.parentNode;
+					var canvasElt = crel('canvas');
+					nomnoml.draw(canvasElt, themeFills + elt.textContent);
+					var pElt = crel('p',	// Wrap <img> in a <p> to mimic markdown image rendering.
+						crel('img', {
+							src: canvasElt.toDataURL('image/png'),
+							alt: 'nomnoml diagram',
+							title: 'nomnoml diagram'	// TODO: Use value from #title directive instead.
+						})
+					);
+					preElt.parentNode.replaceChild(pElt, preElt);
 				}
 				catch(e) {
 				}

--- a/public/res/html/umlDiagramsSettingsBlock.html
+++ b/public/res/html/umlDiagramsSettingsBlock.html
@@ -28,6 +28,17 @@ cond(yes)->e
 cond(no)->op
 ```</code>
 </pre>
+
+<p>nomnoml diagrams:</p>
+<pre><div class="help-block pull-right"><a target="_blank" href="http://www.nomnoml.com/">More info</a></div><code>```nomnoml
+[&lt;abstract&gt;Component||  operation()]
+[Client] depends --&gt; [Component]
+[Decorator|- next: Component]
+[Decorator] decorates -- [ConcreteComponent]
+[Component] &lt;:- [Decorator]
+[Component] &lt;:- [ConcreteComponent]
+```</code></pre>
+
 <blockquote>
     <p><b>Note:</b> Markdown Extra extension has to be enabled with GFM fenced code blocks option.</p>
 </blockquote>

--- a/public/res/main.js
+++ b/public/res/main.js
@@ -17,6 +17,7 @@ requirejs.config({
 	paths: {
 		jquery: 'bower-libs/jquery/jquery',
 		underscore: 'bower-libs/underscore/underscore',
+		lodash: 'bower-libs/lodash/lodash',
 		crel: 'bower-libs/crel/crel',
 		jgrowl: 'bower-libs/jgrowl/jquery.jgrowl',
 		mousetrap: 'bower-libs/mousetrap/mousetrap',
@@ -71,7 +72,8 @@ requirejs.config({
 		'to-markdown': 'bower-libs/to-markdown/src/to-markdown',
 		waitForImages: 'bower-libs/waitForImages/dist/jquery.waitforimages',
 		MathJax: 'bower-libs/MathJax/MathJax',
-		alertify: 'bower-libs/alertify.js/lib/alertify'
+		alertify: 'bower-libs/alertify.js/lib/alertify',
+		nomnoml: 'bower-libs/nomnoml/dist/nomnoml'
 	},
 	shim: {
 		underscore: {


### PR DESCRIPTION
Makes StackEdit capable of rendering [nomnoml](http://www.nomnoml.com) code within fences, much like the other uml features. Fixes issue #645.

This is how it looks in action:

![nomnoml in stackedit](https://cloud.githubusercontent.com/assets/723273/8051056/a2edf1ac-0e77-11e5-9d75-639d02e95978.png)

---

I kept the commit clean, but I'm not entirely sure that's what I should do. Or should I commit the minified build and the messy updates following `gulp bower-requirejs` as well (I think RequireJS got upgraded as well)?

Let me know how you want it and I'll fix it.
