### PR TITLE
Set working version of node docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image.
-FROM node:0.12-onbuild
+FROM node:0.10
 
 # Node base will default the command to `node server.js`.
 


### PR DESCRIPTION
Fix error when running docker build command with node 0.12-onbuild version:

> Status: Downloaded newer image for node:0.12-onbuild
> Executing 3 build triggers
> Trigger 0, COPY package.json /usr/src/app/
> Step 0 : COPY package.json /usr/src/app/
> Trigger 1, RUN npm install
> Step 0 : RUN npm install
> ---> Running in bae4737c1e9d
> npm WARN deprecated gulp-clean@0.3.1: use gulp-rimraf instead
> npm WARN peerDependencies The peer dependency bower@^1.x included from bower-requirejs will >no
> npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
> npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
> <npm WARN prefer global bower@1.4.1 should be installed with -g
> npm ERR! Linux 3.13.0-29-generic
> npm ERR! argv "node" "/usr/local/bin/npm" "install"
> npm ERR! node v0.12.7
> npm ERR! npm  v2.11.3
> 
> npm ERR! shasum check failed for /tmp/npm-5-e023de54/registry.npmjs.org/jshint/-/jshint-2.8.0.tgz
> npm ERR! Expected: 1d09a3bd913c4cadfa81bf18d582bd85bffe0d44
> npm ERR! Actual:   f599a4ca65030850b8b9737f3db59c5386f0ab20
> npm ERR! From:     https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz
> npm ERR! 
> npm ERR! If you need help, you may report this error at:
> npm ERR!     https://github.com/npm/npm/issues
> 
> npm ERR! Please include the following file with any support request:
> npm ERR!     /usr/src/app/npm-debug.log
> The command '/bin/sh -c npm install' returned a non-zero code: 1
