### PR TITLE
Add rich monospaced font option

### DIFF
--- a/public/res/html/bodyEditor.html
+++ b/public/res/html/bodyEditor.html
@@ -1131,6 +1131,12 @@
 									</div>
 									<div class="radio">
 										<label> <input type="radio"
+											name="radio-settings-editor-font-class" value="font-rich-monospaced">
+											Rich Monospaced
+										</label>
+									</div>
+									<div class="radio">
+										<label> <input type="radio"
 											name="radio-settings-editor-font-class" value="font-monospaced">
 											Monospaced
 										</label>

--- a/public/res/styles/main.less
+++ b/public/res/styles/main.less
@@ -1190,6 +1190,10 @@ a {
 		color: fade(@tertiary-color, 25%);
 	}
 
+	&.font-rich-monospaced * {
+		font-family: @font-family-monospace !important;
+	}
+
 	&.font-monospaced * {
 		font-family: @font-family-monospace !important;
 		line-height: @editor-line-weight !important;


### PR DESCRIPTION
Adds a new font option "Rich Monospaced" which sets a monospaced font without removing heading sizes and the like. The result is that underline headings like
```markdown
Heading
=======
```
display nicely in the editor, while retaining the in-editor styling of the rich font option.