### PR TITLE
simplify Linux/OSX launch command in developer's guide

### DIFF
--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -23,7 +23,8 @@ Getting started
 
 - Serve **StackEdit** at `http://localhost/`: 
 
-		(export PORT=80 && node server.js)
+		PORT=80 node server.js
+
   If on Windows, use
   
   		(set PORT=80 && node server.js)


### PR DESCRIPTION
It's not strictly necessary to `export` the value of the `PORT` environment variable.

It can be set on a per-invocation basis with the syntax:

``` bash
PORT=80 node server.js
```

This commit simply changes the `(export PORT=80 && node server.js)` command to the simpler one listed above.

There may be a Windows equivalent to this but I'm not familiar with it.
