### PR TITLE
Update delay before selecting title contents

### DIFF
--- a/public/res/fileMgr.js
+++ b/public/res/fileMgr.js
@@ -165,7 +165,7 @@ define([
 			titleEditing = true;
 			setTimeout(function() {
 				fileTitleInput.focus().get(0).select();
-			}, 10);
+			}, 50);
 		});
 		function applyTitle() {
 			if(!titleEditing) {


### PR DESCRIPTION
Title was not getting selected after creating a new doc (Fast Macbook Pro using Latest Chrome)
When clicking title, selection worked, however.