### PR TITLE
Only use turndown formatted code if it introduces non-whitespace changes

### DIFF
--- a/src/services/editor/cledit/cleditCore.js
+++ b/src/services/editor/cledit/cleditCore.js
@@ -357,7 +357,10 @@ function cledit(contentElt, scrollEltOpt, isMarkdown = false) {
             const sanitizedHtml = htmlSanitizer.sanitizeHtml(html)
               .replace(/&#160;/g, ' '); // Replace non-breaking spaces with classic spaces
             if (sanitizedHtml) {
-              data = turndownService.turndown(sanitizedHtml);
+              const htmlAsMarkdown = turndownService.turndown(sanitizedHtml);
+              if (htmlAsMarkdown.replace(/\s+/g, '') !== data.replace(/\s+/g, '')) {
+                data = htmlAsMarkdown;
+              }
             }
           }
         } catch (e) {


### PR DESCRIPTION
Since the local copy of cledit seems to have diverged from [the public copy](https://github.com/classeur/cledit/blob/master/scripts/cleditCore.js), I assume the local copy of cledit is a fork and that you're ok with modifying it.

This change ensures code pasted from text editors is not formatted improperly.

If there are only white-space changes between the text version and the Turndown formatted version, then we should just use the text version.

Fixes #1364

An alternative solution would be to search the html for html tags that would produce markdown syntax and would not be in code pasted from a text editor. Something like this:

```js
const MARKDOWN_TAG_RE = /<(p|br|h[1-6]|em|i|strong|b|img)(\s|>|\/)/i;

          [...]
          const html = clipboardData.getData('text/html');
          if (html && MARKDOWN_TAG_RE.test(html)) {
```

If that seems like a preferable solution, I don't mind closing this PR and opening a new one.