### PR TITLE
Ensuring profile data is accesible for all Google users

### DIFF
--- a/src/services/providers/helpers/googleHelper.js
+++ b/src/services/providers/helpers/googleHelper.js
@@ -113,7 +113,7 @@ export default {
       {
         client_id: clientId,
         response_type: 'token id_token',
-        scope: ['openid', ...scopes].join(' '),
+        scope: ['openid', 'profile', ...scopes].join(' '),
         hd: appsDomain,
         login_hint: sub,
         prompt: silent ? 'none' : null,


### PR DESCRIPTION
Without requesting 'profile' scope, the `https://www.googleapis.com/plus/v1/people/${sub}` request will return empty values for `name.familyName` and `name.givenName`.

Fixes #1378