### PR TITLE
Allow rotation of Progressive Web App

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -108,6 +108,7 @@ var webpackConfig = merge(baseWebpackConfig, {
       name: 'StackEdit',
       description: 'Full-featured, open-source Markdown editor',
       display: 'standalone',
+      orientation: 'any',
       start_url: 'app',
       background_color: '#ffffff',
       crossorigin: 'use-credentials',


### PR DESCRIPTION
Overriding the default value orientation: 'portrait' with orientation: 'any' of npm module webpack-pwa-manifest to allow rotating StackEdit after it has been added to home screen as progressive web app.