### PR TITLE
Multi Stage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM benweet/stackedit-base
+FROM benweet/stackedit-base AS builder
 
 RUN mkdir -p /opt/stackedit/stackedit_v4
 WORKDIR /opt/stackedit/stackedit_v4
@@ -21,6 +21,11 @@ RUN npm install --unsafe-perm \
 COPY . /opt/stackedit
 ENV NODE_ENV production
 RUN npm run build
+
+FROM mhart/alpine-node:base
+
+COPY --from=builder /opt/stackedit /opt/stackedit
+WORKDIR /opt/stackedit
 
 EXPOSE 8080
 


### PR DESCRIPTION
When I was playing around with the Docker image I noticed that the image was huge (4.6GB uncompressed, 1.9GB compressed).

I tested out building this with a Multi Stage Dockerfile (your ubuntu based image as the builder and [mhart/alpine-node](https://github.com/mhart/alpine-node) as the executor)

The final image size is:
* Uncompressed:
  *  4.6GB (original)
  * 680MB (multi stage)
* Compressed:
  *  1.9GB (original)
  * 190MB (multi stage)

Also, there's the added benefit of fewer CVE's

![image](https://user-images.githubusercontent.com/4052340/48063765-adc9db80-e1ce-11e8-8c3f-b8bdb7dc83ad.png)

Let me know what you think