### PR TITLE
Enabled momentum scrolling

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -12,6 +12,7 @@ body {
 
   /* Prevent body overscroll on Chrome */
   overflow: hidden;
+  -webkit-overflow-scrolling: touch;
 }
 
 * {


### PR DESCRIPTION
Momentum scrolling isn't enabled on mobile Safari for any object other than the main page, so I enabled it. Related to issue #1185