### PR TITLE
Use natural sorting for explorer file nodes.

### DIFF
--- a/src/store/explorer.js
+++ b/src/store/explorer.js
@@ -14,7 +14,7 @@ function debounceAction(action, wait) {
   };
 }
 
-const collator = new Intl.Collator(undefined, { sensitivity: 'base' });
+const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
 const compare = (node1, node2) => collator.compare(node1.item.name, node2.item.name);
 
 class Node {


### PR DESCRIPTION
I order my files by prepending a number.
```
1. Filename
2. Filename
10. Filename
20. Filename
```

The default collation does not use the `numeric` option, so my files get ordered like this:
```
1. Filename
10. Filename
2. Filename
20. Filename
```

This PR updates the explorer sorting to fix into the most common use-case.