### PR TITLE
Fix checkbox not checked on HTML export

### DIFF
--- a/src/extensions/markdownExtension.js
+++ b/src/extensions/markdownExtension.js
@@ -152,7 +152,9 @@ extensionSvc.onSectionPreview((elt, options, isEditor) => {
     const checkboxElt = document.createElement('input');
     checkboxElt.type = 'checkbox';
     checkboxElt.className = 'task-list-item-checkbox';
-    checkboxElt.checked = spanElt.classList.contains('checked');
+    if (spanElt.classList.contains('checked')) {
+      checkboxElt.setAttribute('checked', true);
+    }
     if (!isEditor) {
       checkboxElt.disabled = 'disabled';
     }


### PR DESCRIPTION
`checkboxElt.checked = true;` does not set the `checked` attribute of the input object. Using `setAttribute()` instead fixes #1465