### PR TITLE
fix: allow non-secure GitLab url

### DIFF
--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -293,7 +293,7 @@ export default {
     };
   },
   parseGitlabProjectPath(url) {
-    const parsedProject = url && url.match(/^https:\/\/[^/]+\/(.+?)(?:\.git|\/)?$/);
+    const parsedProject = url && url.match(/^https?:\/\/[^/]+\/(.+?)(?:\.git|\/)?$/);
     return parsedProject && parsedProject[1];
   },
   createHiddenIframe(url) {


### PR DESCRIPTION
In many companies it's normal to use HTTP for intranet sites.
We should allow to access this types of installations