### PR TITLE
Remove references to PageDown usage on Stack Overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://img.shields.io/travis/benweet/stackedit.svg?style=flat)](https://travis-ci.org/benweet/stackedit) [![NPM version](https://img.shields.io/npm/v/stackedit.svg?style=flat)](https://www.npmjs.org/package/stackedit)
 
-> Full-featured, open-source Markdown editor based on PageDown, the Markdown library used by Stack Overflow and the other Stack Exchange sites.
+> Full-featured, open-source Markdown editor based on PageDown.
 
 https://stackedit.io/
 

--- a/static/landing/index.html
+++ b/static/landing/index.html
@@ -8,7 +8,7 @@
     <link rel="shortcut icon" href="static/landing/favicon.ico" type="image/x-icon">
     <meta charset="UTF-8">
     <meta name="description"
-          content="Full-featured, open-source Markdown editor based on PageDown, the Markdown library used by Stack Overflow and the other Stack Exchange sites.">
+          content="Full-featured, open-source Markdown editor based on PageDown.">
     <meta name="author" content="Benoit Schweblin">
     <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="msvalidate.01" content="5E47EE6F67B069C17E3CDD418351A612">
@@ -316,7 +316,7 @@
                 <img class="image" width="410" src="static/landing/navigation-bar.png">
                 <div class="feature">
                     <h3>WYSIWYG controls</h3>
-                    <p>StackEdit provides very handy formatting buttons and shortcuts, thanks to PageDown, the WYSIWYG-style Markdown editor used by Stack Overflow.</p>
+                    <p>StackEdit provides very handy formatting buttons and shortcuts, thanks to PageDown, the WYSIWYG-style Markdown editor.</p>
                 </div>
             </div>
             <div class="row">


### PR DESCRIPTION
Stack Overflow no longer uses PageDown: https://meta.stackexchange.com/questions/348746/were-switching-to-commonmark