### PR TITLE
Master to main

### DIFF
--- a/src/components/modals/providers/GithubOpenModal.vue
+++ b/src/components/modals/providers/GithubOpenModal.vue
@@ -20,7 +20,7 @@
       <form-entry label="Branch" info="optional">
         <input slot="field" class="textfield" type="text" v-model.trim="branch" @keydown.enter="resolve()">
         <div class="form-entry__info">
-          If not supplied, the <code>master</code> branch will be used.
+          If not supplied, the <code>main</code> branch will be used.
         </div>
       </form-entry>
     </div>

--- a/src/components/modals/providers/GithubOpenModal.vue
+++ b/src/components/modals/providers/GithubOpenModal.vue
@@ -59,7 +59,7 @@ export default modalTemplate({
           this.config.token,
           parsedRepo.owner,
           parsedRepo.repo,
-          this.branch || 'master',
+          this.branch || 'main',
           this.path,
         );
         this.config.resolve(location);

--- a/src/components/modals/providers/GithubPublishModal.vue
+++ b/src/components/modals/providers/GithubPublishModal.vue
@@ -74,7 +74,7 @@ export default modalTemplate({
           this.config.token,
           parsedRepo.owner,
           parsedRepo.repo,
-          this.branch || 'master',
+          this.branch || 'main',
           this.path,
         );
         location.templateId = this.selectedTemplate;

--- a/src/components/modals/providers/GithubSaveModal.vue
+++ b/src/components/modals/providers/GithubSaveModal.vue
@@ -62,7 +62,7 @@ export default modalTemplate({
           this.config.token,
           parsedRepo.owner,
           parsedRepo.repo,
-          this.branch || 'master',
+          this.branch || 'main',
           this.path,
         );
         this.config.resolve(location);

--- a/src/components/modals/providers/GithubWorkspaceModal.vue
+++ b/src/components/modals/providers/GithubWorkspaceModal.vue
@@ -53,7 +53,7 @@ export default modalTemplate({
         const url = utils.addQueryParams('app', {
           ...parsedRepo,
           providerId: 'githubWorkspace',
-          branch: this.branch || 'master',
+          branch: this.branch || 'main',
           path: path || undefined,
         }, true);
         this.config.resolve();

--- a/src/services/providers/githubWorkspaceProvider.js
+++ b/src/services/providers/githubWorkspaceProvider.js
@@ -48,7 +48,7 @@ export default new Provider({
     const { owner, repo, branch } = utils.queryParams;
     const workspaceParams = this.getWorkspaceParams({ owner, repo, branch });
     if (!branch) {
-      workspaceParams.branch = 'master';
+      workspaceParams.branch = 'main';
     }
 
     // Extract path param


### PR DESCRIPTION
Last year GitHub renamed the default branch from `master` to `main`, therefore when opening from GitHub without specifying a branch, the old default would have been used, eventually throwing an error. Now it should work properly.