### PR TITLE
Fix deprecated auth method

### DIFF
--- a/src/services/providers/helpers/githubHelper.js
+++ b/src/services/providers/helpers/githubHelper.js
@@ -89,8 +89,8 @@ export default {
     const user = (await networkSvc.request({
       method: 'GET',
       url: 'https://api.github.com/user',
-      params: {
-        access_token: accessToken,
+      headers: {
+         authorization: 'token '+accessToken,
       },
     })).body;
     userSvc.addUserInfo({


### PR DESCRIPTION
Fixing this:
https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/
Merge this before 05/05/2021 or the GitHub connection will be broken for everyone