### PR TITLE
Attempting to connect a github account is failing with a 400 error

### DIFF
--- a/src/services/providers/helpers/githubHelper.js
+++ b/src/services/providers/helpers/githubHelper.js
@@ -86,12 +86,9 @@ export default {
     })).body;
 
     // Call the user info endpoint
-    const user = (await networkSvc.request({
+    const user = (await request(accessToken, {
       method: 'GET',
       url: 'https://api.github.com/user',
-      params: {
-        access_token: accessToken,
-      },
     })).body;
     userSvc.addUserInfo({
       id: `${subPrefix}:${user.id}`,


### PR DESCRIPTION
The 400 error points to this page  https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/ .

This call to get the user info is using a deprecated authentication method (passing access_token param).  Updated to use the existing request method which uses the header based authentication.

I apologize, I don't have the required clientId/secret to test this fix, and not sure if it has to be deployed on something other than localhost to test it.  Hopefully this is a simple change to test.