### PR TITLE
added a way to run the app instantly

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ helm install --name stackedit stackedit/stackedit \
   --set ingress.tls[0].secretName=stackedit-tls \
   --set ingress.tls[0].hosts[0]=stackedit.example.com
 ```
+### [Run without installation]([![TeamCode try-it-now](https://static01.teamcode.com/badge/demo.svg)](https://www.teamcode.com/tin/clone?applicationId=273128516352372736))

--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ helm install --name stackedit stackedit/stackedit \
   --set ingress.tls[0].secretName=stackedit-tls \
   --set ingress.tls[0].hosts[0]=stackedit.example.com
 ```
-### [Run without installation]([![TeamCode try-it-now](https://static01.teamcode.com/badge/demo.svg)](https://www.teamcode.com/tin/clone?applicationId=273128516352372736))
+### Run without installation [![TeamCode try-it-now](https://static01.teamcode.com/badge/demo.svg)](https://www.teamcode.com/tin/clone?applicationId=273128516352372736)


### PR DESCRIPTION
Hello, we are TeamCode. We have created a Tin application for this app, which help users to quickly run and try the app without installing and configuring the environment. Users don't need to pay for this service. Hope it can help you better promote the app. Thx.

[![TeamCode try-it-now](https://static01.teamcode.com/badge/demo.svg)](https://www.teamcode.com/tin/clone?applicationId=273128516352372736)
Guidance: https://www.teamcode.com/docs/en-US/tin/clone-tin

This is the entire usage process：

Users click the badge Run in Cloud.
Sign up first if they have not logged in.
After that, they will be directed to the Clone page and start to build & run this app.