### PR TITLE
Fixed can not open couchdb credentials.

### DIFF
--- a/src/services/providers/helpers/couchdbHelper.js
+++ b/src/services/providers/helpers/couchdbHelper.js
@@ -21,8 +21,8 @@ const request = async (token, options = {}) => {
         url: utils.resolveUrl(baseUrl, '../_session'),
         withCredentials: true,
         body: {
-          name,
-          password,
+          name: name || '',
+          password: password || '',
         },
       });
     } catch (err) {


### PR DESCRIPTION
This fix if couchdb need credentials, credentials page can not open issues.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality