### PR TITLE
Remove scrollbars and wrap code blocks in print mode

### DIFF
--- a/src/styles/prism.scss
+++ b/src/styles/prism.scss
@@ -71,3 +71,11 @@
     font-style: italic;
   }
 }
+@media print {
+  pre, code {
+    overflow: visible !important;
+    white-space: pre-wrap !important;
+    word-break: break-word !important;
+  }
+}
+


### PR DESCRIPTION
Added print mode CSS to remove scrollbars from code blocks and enable wrapping for better readability in PDF and paper exports. Tested using print preview and PDF export. No functional code modified.